### PR TITLE
Restore `create_order` Link in Farmer Profiles Diagnose Method

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1162,3 +1162,5 @@ This endpoint is idempotent. If the dealer is already verified, it will return s
   "error": "AgroDealer not found."
 }
 ```
+
+# todo: Update docs with order creation, payment callback and redirect, crop scans, treatments search

--- a/backend/app/controllers/farmer_profiles_controller.ts
+++ b/backend/app/controllers/farmer_profiles_controller.ts
@@ -9,6 +9,7 @@ import { rules } from '#services/validator_rules'
 import router from '@adonisjs/core/services/router'
 import CropScan from '#models/crop_scan'
 import { ProductCategory } from '#models/product'
+import { ModelObject } from '@adonisjs/lucid/types/model'
 
 export default class FarmerProfilesController {
   /**
@@ -234,7 +235,18 @@ export default class FarmerProfilesController {
           disease: aiResult.disease,
           instructions: aiResult.instructions,
         },
-        treatments: result?.rows ?? [],
+        treatments:
+          result?.rows && result.rows.length
+            ? result.rows.map((row: ModelObject /** todo: provide type */) => ({
+                ...row,
+                links: {
+                  create_order: {
+                    method: 'POST',
+                    href: router.makeUrl('api.v1.products.orders.store', [row.id]),
+                  },
+                },
+              }))
+            : [],
       },
     })
   }

--- a/backend/app/controllers/products_controller.ts
+++ b/backend/app/controllers/products_controller.ts
@@ -216,6 +216,7 @@ export default class ProductsController {
         'price',
         'stock_quantity',
         'target_problems',
+        'active_ingredient',
         'description',
         'created_at',
         'updated_at',


### PR DESCRIPTION
This PR:
- restores `create_order` links object in `diagnose` controller method
- selects `active_ingredient` in `#getProduct` method in products controller
- updates docs with todo endpoints