### PR TITLE
Fix Route Imports

### DIFF
--- a/start/routes.ts
+++ b/start/routes.ts
@@ -7,13 +7,13 @@
 |
 */
 
-import('#start/routes/api/v1/user_routes')
-import('#start/routes/api/v1/agro_dealer_profile_routes')
-import('#start/routes/api/v1/farmer_profile_routes')
-import('#start/routes/api/v1/authentication_routes')
-import('#start/routes/api/v1/bank_routes')
-import('#start/routes/api/v1/crop_scan_routes')
-import('#start/routes/api/v1/product_routes')
-import('#start/routes/api/v1/order_routes')
-import('#start/routes/api/v1/payment_routes')
-import('#start/routes/api/v1/webhook_routes')
+import '#start/routes/api/v1/user_routes'
+import '#start/routes/api/v1/agro_dealer_profile_routes'
+import '#start/routes/api/v1/farmer_profile_routes'
+import '#start/routes/api/v1/authentication_routes'
+import '#start/routes/api/v1/bank_routes'
+import '#start/routes/api/v1/crop_scan_routes'
+import '#start/routes/api/v1/product_routes'
+import '#start/routes/api/v1/order_routes'
+import '#start/routes/api/v1/payment_routes'
+import '#start/routes/api/v1/webhook_routes'

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -7,13 +7,13 @@
 |
 */
 
-import('./routes/api/v1/user_routes.js')
-import('./routes/api/v1/agro_dealer_profile_routes.js')
-import('./routes/api/v1/farmer_profile_routes.js')
-import('./routes/api/v1/authentication_routes.js')
-import('./routes/api/v1/bank_routes.js')
-import('./routes/api/v1/crop_scan_routes.js')
-import('./routes/api/v1/product_routes.js')
-import('./routes/api/v1/order_routes.js')
-import('./routes/api/v1/payment_routes.js')
-import('./routes/api/v1/webhook_routes.js')
+import('#start/routes/api/v1/user_routes')
+import('#start/routes/api/v1/agro_dealer_profile_routes')
+import('#start/routes/api/v1/farmer_profile_routes')
+import('#start/routes/api/v1/authentication_routes')
+import('#start/routes/api/v1/bank_routes')
+import('#start/routes/api/v1/crop_scan_routes')
+import('#start/routes/api/v1/product_routes')
+import('#start/routes/api/v1/order_routes')
+import('#start/routes/api/v1/payment_routes')
+import('#start/routes/api/v1/webhook_routes')


### PR DESCRIPTION
This PR fixes an issue that arose after splitting routes into separate files and importing them centrally in this PR: https://github.com/FarmXnap/FarmXnap-Backend/pull/7.
Some routes became unavailable for requests and could not be seen after running the command `node ace list:routes`.

The PR fixes the issue by switching from dynamic imports (`import('#start/routes/api/v1/user_routes')`) to static imports (`import '#start/routes/api/v1/user_routes'`) in the `routes.ts` file to ensure that all routes are loaded and available when the app boots.

The tests for the endpoints did not catch this issue because, in the millisecond between the app starting and the test running, those promises from the dynamic imports are resolved before the test code triggers the route.

---

The PR also switches syntax from relative path imports (`'./routes/api/v1/user_routes.js'`) to the more elegant subpath aliasing (`'#start/routes/api/v1/user_routes'`) provided by Adonis v6.