### PR TITLE
Make the Crop Scan & Diagnose Endpoint Resourceful

### DIFF
--- a/README.md
+++ b/README.md
@@ -980,7 +980,7 @@ JSON
 
 ### **15. Scan an image and get diagnosis and treatment results**
 
-- **Endpoint:** `POST /farmer_profiles/:farmer_profile_id/diagnose`
+- **Endpoint:** `POST /crop_scans`
 - **Auth Required:** Yes
 - **Authorization:** `farmer` role
 - **Content-Type:** `multipart/form-data`
@@ -1256,7 +1256,7 @@ NB: For a healthy crop, the `disease` field is `null` and no `get_treatments` li
 
 ### **Frontend Implementation Note**
 
-> The same structure for the `treatments` array returned in the diagnose endpoint (`POST /farmer_profiles/:farmer_profile_id/diagnose`) is returned in `data` for this endpoint. Client should also use the `rank` field for UI/UX labelling as mentioned earlier.
+> The same structure for the `treatments` array returned in the crop scan & diagnose endpoint (`POST /crop_scans`) is returned in `data` for this endpoint. Client should also use the `rank` field for UI/UX labelling as mentioned earlier.
 
 > If the crop scan was for a healthy crop, a success response is still returned with an empty data array. This should be unnecessary if the client complies with the server's HATEOAS standard, because the `get_treatments` link is not returned for healthy crop.
 

--- a/app/controllers/crop_scans_controller.ts
+++ b/app/controllers/crop_scans_controller.ts
@@ -2,7 +2,10 @@ import type { HttpContext } from '@adonisjs/core/http'
 import CropScan from '#models/crop_scan'
 import { getCropTreatmentResults } from '../../helpers/crop_scan_helper.js'
 import router from '@adonisjs/core/services/router'
-
+import fs from 'node:fs/promises'
+import AiService, { AIDiagnosis } from '#services/ai_service'
+import { ProductCategory } from '#models/product'
+import { schema } from '@adonisjs/validator'
 export default class CropScansController {
   /**
    * Get crop scan history.
@@ -57,6 +60,103 @@ export default class CropScansController {
               },
             }))
           : [],
+    })
+  }
+
+  /**
+   * Scan a crop and get diagnosis and treatment results.
+   *
+   * `POST /api/v1/crop_scans`
+   */
+  public async store({ request, response, auth }: HttpContext) {
+    const user = auth.user!
+
+    const maxSize = '10mb'
+    const supportedExtNames = ['jpg', 'jpeg', 'png', 'webp', 'heic', 'heif']
+
+    const { image } = await request.validate({
+      schema: schema.create({
+        image: schema.file({
+          size: maxSize,
+          extnames: supportedExtNames,
+        }),
+      }),
+      messages: {
+        'image.required': 'Image is required.',
+        'image.file.size': `Image size must not exceed ${maxSize}.`,
+        'image.file.extname': `Image extension is not supported. Only ${supportedExtNames.join(', ')} are supported.`,
+      },
+    })
+
+    if (!image.tmpPath) {
+      return response.badRequest({ error: 'File upload failed' })
+    }
+
+    const imageBuffer = await fs.readFile(image.tmpPath)
+
+    const mimeType = image.extname === 'jpg' ? 'image/jpeg' : `image/${image.extname}`
+
+    let aiResult: AIDiagnosis | null = null
+
+    try {
+      aiResult = await AiService.diagnose(imageBuffer, mimeType)
+    } catch {}
+
+    if (!aiResult) {
+      return response.ok({ data: [] })
+    }
+
+    if (aiResult.crop === 'INVALID') {
+      return response.badRequest({ error: aiResult.instructions })
+    }
+
+    await user.load('farmerProfile')
+
+    const isHealthy = aiResult.disease === 'HEALTHY'
+
+    await CropScan.create({
+      farmer_profile_id: user.farmerProfile!.id,
+      crop: aiResult.crop,
+      disease: isHealthy ? null : aiResult.disease,
+      instructions: aiResult.instructions,
+      search_term: isHealthy ? null : aiResult.search_term,
+      active_ingredient: isHealthy ? null : aiResult.active_ingredient,
+      category: isHealthy ? null : (aiResult.category as ProductCategory),
+    })
+
+    if (aiResult.disease === 'HEALTHY') {
+      return response.ok({
+        data: {
+          diagnosis: {
+            instructions: aiResult.instructions,
+            crop: aiResult.crop,
+          },
+        },
+      })
+    }
+
+    const result = await getCropTreatmentResults(aiResult)
+
+    return response.ok({
+      data: {
+        diagnosis: {
+          crop: aiResult.crop,
+          disease: aiResult.disease,
+          instructions: aiResult.instructions,
+        },
+        treatments:
+          result?.rows && result.rows.length
+            ? result.rows.map((row) => ({
+                ...row,
+                links: {
+                  create_order: {
+                    method: 'POST',
+                    href: router.makeUrl('api.v1.products.orders.store', [row.id]),
+                  },
+                },
+              }))
+            : [],
+      },
     })
   }
 }

--- a/app/controllers/farmer_profiles_controller.ts
+++ b/app/controllers/farmer_profiles_controller.ts
@@ -3,13 +3,8 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { schema } from '@adonisjs/validator'
 import hash from '@adonisjs/core/services/hash'
 import db from '@adonisjs/lucid/services/db'
-import fs from 'node:fs/promises'
-import AiService, { AIDiagnosis } from '#services/ai_service'
 import { rules } from '#services/validator_rules'
 import router from '@adonisjs/core/services/router'
-import CropScan from '#models/crop_scan'
-import { ProductCategory } from '#models/product'
-import { getCropTreatmentResults } from '../../helpers/crop_scan_helper.js'
 
 export default class FarmerProfilesController {
   /**
@@ -152,103 +147,9 @@ export default class FarmerProfilesController {
         phone_number: user.phone_number,
         role: user.role,
         farmerProfile: user.farmerProfile,
-      },
-    })
-  }
-
-  /**
-   * Scan a crop and get diagnosis and treatment results.
-   *
-   * `POST /api/v1/farmer_profiles/:farmer_profile_id/diagnose`
-   */
-  public async diagnose({ request, response, auth }: HttpContext) {
-    const user = auth.user!
-
-    const maxSize = '10mb'
-    const supportedExtNames = ['jpg', 'jpeg', 'png', 'webp', 'heic', 'heif']
-
-    const { image } = await request.validate({
-      schema: schema.create({
-        image: schema.file({
-          size: maxSize,
-          extnames: supportedExtNames,
-        }),
-      }),
-      messages: {
-        'image.required': 'Image is required.',
-        'image.file.size': `Image size must not exceed ${maxSize}.`,
-        'image.file.extname': `Image extension is not supported. Only ${supportedExtNames.join(', ')} are supported.`,
-      },
-    })
-
-    if (!image.tmpPath) {
-      return response.badRequest({ error: 'File upload failed' })
-    }
-
-    const imageBuffer = await fs.readFile(image.tmpPath)
-
-    const mimeType = image.extname === 'jpg' ? 'image/jpeg' : `image/${image.extname}`
-
-    let aiResult: AIDiagnosis | null = null
-
-    try {
-      aiResult = await AiService.diagnose(imageBuffer, mimeType)
-    } catch {}
-
-    if (!aiResult) {
-      return response.ok({ data: [] })
-    }
-
-    if (aiResult.crop === 'INVALID') {
-      return response.badRequest({ error: aiResult.instructions })
-    }
-
-    await user.load('farmerProfile')
-
-    const isHealthy = aiResult.disease === 'HEALTHY'
-
-    await CropScan.create({
-      farmer_profile_id: user.farmerProfile!.id,
-      crop: aiResult.crop,
-      disease: isHealthy ? null : aiResult.disease,
-      instructions: aiResult.instructions,
-      search_term: isHealthy ? null : aiResult.search_term,
-      active_ingredient: isHealthy ? null : aiResult.active_ingredient,
-      category: isHealthy ? null : (aiResult.category as ProductCategory),
-    })
-
-    if (aiResult.disease === 'HEALTHY') {
-      return response.ok({
-        data: {
-          diagnosis: {
-            instructions: aiResult.instructions,
-            crop: aiResult.crop,
-          },
-        },
-      })
-    }
-
-    const result = await getCropTreatmentResults(aiResult)
-
-    return response.ok({
-      data: {
-        diagnosis: {
-          crop: aiResult.crop,
-          disease: aiResult.disease,
-          instructions: aiResult.instructions,
-        },
-        treatments:
-          result?.rows && result.rows.length
-            ? result.rows.map((row) => ({
-                ...row,
-                links: {
-                  create_order: {
-                    method: 'POST',
-                    href: router.makeUrl('api.v1.products.orders.store', [row.id]),
-                  },
-                },
-              }))
-            : [],
+        /**
+         * @todo: Decide whether to return the crop scan store endpoint in links.
+         */
       },
     })
   }

--- a/start/routes/api/v1/crop_scan_routes.ts
+++ b/start/routes/api/v1/crop_scan_routes.ts
@@ -8,7 +8,7 @@ router
     router
       .resource('crop_scans', () => import('#controllers/crop_scans_controller'))
       .apiOnly()
-      .only(['index'])
+      .only(['index', 'store'])
 
     // Route to get treatment results for a crop scan
     router

--- a/start/routes/api/v1/farmer_profile_routes.ts
+++ b/start/routes/api/v1/farmer_profile_routes.ts
@@ -10,15 +10,6 @@ router
       .apiOnly()
       .only(['store', 'show'])
       .middleware('show', [middleware.auth(), middleware.role({ role: UserRolesEnum.Farmer })])
-
-    // Route for farmer to scan a crop and get treatment results.
-    router
-      .post('farmer_profiles/:farmer_profile_id/diagnose', [
-        () => import('#controllers/farmer_profiles_controller'),
-        'diagnose',
-      ])
-      .as('farmer_profiles.diagnose')
-      .use([middleware.auth(), middleware.role({ role: UserRolesEnum.Farmer })])
   })
   .prefix('api/v1')
   .as('api.v1')

--- a/tests/functional/crop_scans/store.spec.ts
+++ b/tests/functional/crop_scans/store.spec.ts
@@ -22,7 +22,7 @@ import {
 
 const heavyFilePath = app.makePath('tmp', 'tests', 'too_large.jpg')
 
-test.group('Farmer Profiles / Diagnose', (group) => {
+test.group('Crop Scans / Store', (group) => {
   group.each.setup(async () => {
     await db.beginGlobalTransaction()
 
@@ -100,7 +100,7 @@ test.group('Farmer Profiles / Diagnose', (group) => {
       }
 
       const response = await client
-        .post(route('api.v1.farmer_profiles.diagnose', [farmer.id]))
+        .post(route('api.v1.crop_scans.store'))
         .file(
           condition === 'image_not_provided' ? '' : 'image',
           condition === 'image_size_exceeded'
@@ -221,6 +221,6 @@ test.group('Farmer Profiles / Diagnose', (group) => {
         category: mockAiResponseDiseasedCrop.category,
       })
     })
-    .tags(['farmer_profiles', 'diagnose'])
+    .tags(['crop_scans', 'create_crop_scan', 'diagnose'])
   // .timeout(30000)
 })


### PR DESCRIPTION
This PR makes the crop scan & diagnose endpoint resourceful. It:
- moves the route from `farmer_profile_routes` to `crop_scan_routes`
- moves the controller method from `farmer_profiles_controller.diagnose` into `crop_scans.store`
- moves the test file accordingly
- update the docs in README