### PR TITLE
Configure ACME Support for SSL/TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ yarn-error.log
 
 # Platform specific
 .DS_Store
+
+# Infra
+certbot/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       - '80:80'
     volumes:
       - ./infra/nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./certbot/www:/var/www/certbot:ro
+      - ./certbot/conf:/etc/letsencrypt:ro
     depends_on:
       - app
 

--- a/infra/nginx/conf.d/default.conf
+++ b/infra/nginx/conf.d/default.conf
@@ -5,6 +5,10 @@ server {
     # Max upload size (AdonisJS default is 20MB)
     client_max_body_size 20M;
 
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
     location / {
         proxy_pass http://app:3333;
         


### PR DESCRIPTION
This PR configures ACME support for SSL/TLS. It:
- adds nginx location block for `.well-known/acme-challenge/` to support Let's Encrypt domain verification
- configures Docker volumes between host and Nginx container for Certbot webroot and certificate storage
- adds the `certbot` folder to `.gitignore`