### PR TITLE
Enable HTTPS and Port 443 and Configure SSL Certificates and Secure Protocols

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     image: nginx:alpine
     ports:
       - '80:80'
+      - '443:443'
     volumes:
       - ./infra/nginx/conf.d:/etc/nginx/conf.d:ro
       - ./certbot/www:/var/www/certbot:ro

--- a/infra/nginx/conf.d/default.conf
+++ b/infra/nginx/conf.d/default.conf
@@ -5,9 +5,28 @@ server {
     # Max upload size (AdonisJS default is 20MB)
     client_max_body_size 20M;
 
+    # For CertBot renewals
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
     }
+
+    # Redirect all http to https
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443;
+    server_name farmxnap-api.duckdns.org;
+
+    # Point to the certificates
+    ssl_certificate /etc/letsencrypt/live/farmxnap-api.duckdns.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/farmxnap-api.duckdns.org/privkey.pem;
+
+    # Security settings
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
 
     location / {
         proxy_pass http://app:3333;


### PR DESCRIPTION
After successful ACME configuration of SSL/TLS (https://github.com/FarmXnap/FarmXnap-Backend/pull/11, https://github.com/FarmXnap/FarmXnap-Backend/pull/12) and certificate installation on the server, this PR enables HTTPS and port 443 with Nginx. It:
- adds port 443 mapping to docker-compose
- configures Nginx with SSL certificates and secure TLS protocols
- implements  automatic HTTP to HTTPS redirection