### PR TITLE
Add Missing `ssl `Directive to Nginx Listen

### DIFF
--- a/infra/nginx/conf.d/default.conf
+++ b/infra/nginx/conf.d/default.conf
@@ -17,7 +17,7 @@ server {
 }
 
 server {
-    listen 443;
+    listen 443 ssl;
     server_name farmxnap-api.duckdns.org;
 
     # Point to the certificates


### PR DESCRIPTION
This PR is a continuation/fix for this PR https://github.com/FarmXnap/FarmXnap-Backend/pull/13. It fixes this error that was returned after making a request to the https endpoint:
```
write EPROTO 39187282135424:error:100000f7:SSL routines:OPENSSL_internal:WRONG_VERSION_NUMBER:../../third_party/boringssl/src/ssl/tls_record.cc:127:
```
The `ssl` directive was missing in the nginx conf.