### PR TITLE
Run Database Migrations Automatically after Deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,4 +22,5 @@ jobs:
             cd ~/FarmXnap-Backend
             git pull origin main
             docker compose up --build -d
+            docker compose exec -T app node build/ace migration:run --force
             docker system prune -f


### PR DESCRIPTION
As an improvement to this PR: https://github.com/FarmXnap/FarmXnap-Backend/pull/15, this PR updates the deployment file to run database migrations automatically after deployment.

This approach is favoured (over running it at Docker entrypoint stage) for now because it allows for easier debugging of migration output in the GitHub Actions logs.