### PR TITLE
Fix Staging and Production Environment Isolation

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -13,4 +13,5 @@ jobs:
       folder: production
       services: app redis db nginx
       app_name: app
+      profile: production
     secrets: inherit

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -13,4 +13,5 @@ jobs:
       folder: staging
       services: app-staging redis-staging db-staging
       app_name: app-staging
+      profile: staging
     secrets: inherit

--- a/.github/workflows/reusable_deploy.yml
+++ b/.github/workflows/reusable_deploy.yml
@@ -13,6 +13,9 @@ on:
       app_name:
         required: true
         type: string
+      profile:
+        required: true
+        type: string
     secrets:
       REMOTE_HOST:
         required: true
@@ -37,6 +40,6 @@ jobs:
           script: |
             cd ~/farmxnap/${{inputs.folder}}
             git pull origin ${{inputs.branch}}
-            docker compose up --build -d ${{inputs.services}}
-            docker compose exec -T ${{inputs.app_name}} node build/ace migration:run --force
+            docker compose --profile ${{inputs.profile}} up --build -d
+            docker compose --profile ${{inputs.profile}} exec -T ${{inputs.app_name}} node build/ace migration:run --force
             docker system prune -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,20 +11,31 @@ services:
       - ${SSL_PATH}:/etc/letsencrypt:ro
     depends_on:
       - app
-      - app-staging
+    networks:
+      - farmxnap-shared-network
+    profiles:
+      - production
 
   # PRODUCTION
   app:
     build: .
     restart: always
     env_file: .env
+    networks:
+      - farmxnap-shared-network
     depends_on:
       - db
       - redis
+    profiles:
+      - production
 
   redis:
     image: redis:alpine
     restart: always
+    networks:
+      - farmxnap-shared-network
+    profiles:
+      - production
 
   db:
     image: postgres:15-alpine
@@ -35,19 +46,31 @@ services:
       - POSTGRES_PASSWORD=${DB_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    networks:
+      - farmxnap-shared-network
+    profiles:
+      - production
 
   # STAGING
   app-staging:
     build: .
     restart: always
     env_file: .env
+    networks:
+      - farmxnap-shared-network
     depends_on:
       - db-staging
       - redis-staging
+    profiles:
+      - staging
 
   redis-staging:
     image: redis:alpine
     restart: always
+    networks:
+      - farmxnap-shared-network
+    profiles:
+      - staging
 
   db-staging:
     image: postgres:15-alpine
@@ -58,7 +81,14 @@ services:
       - POSTGRES_PASSWORD=${DB_PASSWORD}
     volumes:
       - postgres_data_staging:/var/lib/postgresql/data
+    networks:
+      - farmxnap-shared-network
+    profiles:
+      - staging
 
 volumes:
   postgres_data:
   postgres_data_staging:
+
+networks:
+  farmxnap-shared-network:

--- a/infra/nginx/conf.d/default.conf
+++ b/infra/nginx/conf.d/default.conf
@@ -23,7 +23,7 @@ server {
     ssl_certificate /etc/letsencrypt/live/farmxnap-api.duckdns.org/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/farmxnap-api.duckdns.org/privkey.pem;
 
-   include params/ssl_params;
+    include params/ssl_params;
 
     location / {
         proxy_pass http://app:3333;
@@ -41,11 +41,12 @@ server {
     ssl_certificate /etc/letsencrypt/live/farmxnap-staging-api.duckdns.org/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/farmxnap-staging-api.duckdns.org/privkey.pem;
 
-   include params/ssl_params;
+    include params/ssl_params;
 
     location / {
-        proxy_pass http://app-staging:3333;
-        
+        resolver 127.0.0.11 valid=10s;
+        set $upstream http://app-staging:3333;
+        proxy_pass $upstream;
         include params/proxy_params;
     }
 }


### PR DESCRIPTION
This PR is an improvement/fix for this PR https://github.com/FarmXnap/FarmXnap-Backend/pull/18. It was observed that data from the staging api ended up in the production database. This PR properly isolates the staging and production environments. It:
- splits services into production and staging profiles in `docker-compose.yml` to prevent production from spawning rogue staging containers
- adds shared network so nginx can reach app-staging across profiles
-  scopes nginx `depends_on` to app only since app-staging is in staging profile
- updates nginx conf to use Docker resolver and dynamic upstream variable for app-staging so nginx starts independently of staging container state
- passes in the appropriate profile from the deployment files and updates `reusable_deploy.yml` to start the containers and run migrations with  the appropriate profile