### PR TITLE
Set Explicit Network Name to Prevent Docker Compose Project Prefix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,3 +92,4 @@ volumes:
 
 networks:
   farmxnap-shared-network:
+    name: farmxnap-shared-network


### PR DESCRIPTION
This PR is an improvement/fix for this PR: https://github.com/FarmXnap/FarmXnap-Backend/pull/19. It fixes an issue where the staging app could not be resolved.

Because, on the server, both folders have their own compose project name (production and staging), Docker prefixes the network name with the project name. So instead of one shared network, there were separate networks:

`production_farmxnap-shared-network`
`staging_farmxnap-shared-network`

Nginx could therefore not reach app-staging.

This PR forces a consistent network name across both projects.