### PR TITLE
Fix Database Backup Folder Prefix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM node:24-alpine
 
 WORKDIR /app
 
-RUN apk add --no-cache postgresql-client
+RUN apk add --no-cache postgresql15-client
 
 # Copy only the compiled code from the builder stage to save space
 COPY --from=builder /app/build ./build

--- a/app/services/database_backup_service.ts
+++ b/app/services/database_backup_service.ts
@@ -29,7 +29,7 @@ export default class DatabaseBackupService {
       },
     })
 
-    const fileName = `${env.get('NODE_ENV') /**Different folders per environment in the bucket */}/db-backup-${DateTime.now().toFormat('yyyy-MM-dd-HHmm')}.dump`
+    const fileName = `${env.get('APP_ENV') || env.get('NODE_ENV') /**Different folders per environment in the bucket */}/db-backup-${DateTime.now().toFormat('yyyy-MM-dd-HHmm-ss')}.dump`
 
     logger.info({ fileName }, '[DatabaseBackupService.run] Starting database backup...')
 


### PR DESCRIPTION
This PR is an improvement on this PR https://github.com/FarmXnap/FarmXnap-Backend/pull/21.
It improves the `DatabaseBackupService` to use both NODE_ENV and APP_ENV for S3 key prefix to prevent Staging and Production backups from overriding each other.
NB: Both staging and production share the same `NODE_ENV` value, `production`. The difference is the `APP_ENV` which is set to `staging` for staging environment, and is undefined for other environments.

---

An observation was also made when trying to restore a database backup file of the remote server locally. The remote container postgres version is identical with the local postgres version, yet on attempting to restore the dump locally, this error was thrown:
```bash
$ pg_restore -h localhost -U postgres -d demo_fxp -c --if-exists ~/Downloads/db-backup-2026-05-05-0000.dump
pg_restore: error: unsupported version (1.16) in file header
```
This is because the postgresql-client in the Dockerfile used to run the `pg_dump` command is of a newer version than the postgresql-client used to run the `pg_restore` command (For pg_restore to work, the version used to restore must be the same or newer than the version used to dump).

There is a mismatch in the postgres versions used by the app and the db containers on the server:
```bash
$ docker compose exec db pg_dump --version
pg_dump (PostgreSQL) 15.17
$ docker compose exec app pg_dump --version
pg_dump (PostgreSQL) 18.3
```

For consistency, this PR pins the postgresql-client in the Dockerfile to a specific version, to match the postgres version in the docker-compose file.




