### PR TITLE
Pin `postgres-client` to v15 for Database Compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ FROM node:24-alpine
 
 WORKDIR /app
 
-RUN apk add --no-cache postgresql15-client
+# Use Alpine v3.17 repo to pin pg_dump to v15 for compatibility with
+# our DB container, avoiding the higher v18 in newer Alpine.
+RUN apk add --no-cache postgresql15-client --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main
 
 # Copy only the compiled code from the builder stage to save space
 COPY --from=builder /app/build ./build


### PR DESCRIPTION
This PR is an improvement on the second section of this PR: https://github.com/FarmXnap/FarmXnap-Backend/pull/22. This was observed in the deployment build logs:

```
 > [stage-1 3/6] RUN apk add --no-cache postgresql15-client:
1.234 ERROR: unable to select packages:
1.234   postgresql15-client (no such package):
1.234     required by: world[postgresql15-client]
------
Dockerfile:19
```
The older postgres v15 we need for pg_dump is not available in the version of Alpine our Node 24 image is based on.

This PR forces the use of the Alpine v3.17 repository because newer Alpine versions (shipped with Node 24) default to PG 17/18. We need the v15 client to ensure backup compatibility with our PostgreSQL 15 database container.