### PR TITLE
Restrict Backup Worker and Schedule to Production & Staging

### DIFF
--- a/providers/queue_provider.ts
+++ b/providers/queue_provider.ts
@@ -37,6 +37,10 @@ export default class QueueProvider {
       },
     })
 
+    if (!this.app.inProduction) {
+      return
+    }
+
     const dbBackupsJobName = 'daily-db-backups'
 
     // Create the worker

--- a/providers/queue_provider.ts
+++ b/providers/queue_provider.ts
@@ -37,6 +37,7 @@ export default class QueueProvider {
       },
     })
 
+    // Run only in production and staging.
     if (!this.app.inProduction) {
       return
     }


### PR DESCRIPTION
This PR modifies the `QueueProvider` to initialize the backups queue in all environments while restricting the Worker and the daily-db-backups repeatable job to production and staging. This prevents unintended backups and logs during local development, migrations, and testing.