### PR TITLE
[Fix: Payment System] Store Provider Name on Transaction Creation

### DIFF
--- a/app/controllers/wallets_controller.ts
+++ b/app/controllers/wallets_controller.ts
@@ -63,23 +63,22 @@ export default class WalletsController {
 
     const amountInMinorUnit = convertAmountToMinorUnit(amountInMainUnit)
 
-    const transaction = await Transaction.create({
+    await Transaction.create({
       category: TransactionCategoriesEnum.Topup,
       type: TransactionTypesEnum.Credit,
       status: TransactionStatusesEnum.Pending,
       reference: ref,
       wallet_id: walletId,
       amount: amountInMinorUnit,
+      provider: this.paymentService.providerName,
     })
 
-    const { data, paymentProviderName } = await this.paymentService.initializeWalletTopup({
+    const { data } = await this.paymentService.initializeWalletTopup({
       email,
       amount: amountInMinorUnit,
       walletId,
       reference: ref,
     })
-
-    await transaction.merge({ provider: paymentProviderName }).save()
 
     const { access_code: accessCode, authorization_url: authorizationUrl, reference } = data
 
@@ -124,10 +123,11 @@ export default class WalletsController {
       return response.notFound({ error: 'No wallet found for the user.' })
     }
 
-    const { response: providerResponse, paymentProviderName } =
-      await this.paymentService.verifyWalletTopup({
-        reference,
-      })
+    const { response: providerResponse } = await this.paymentService.verifyWalletTopup({
+      reference,
+    })
+
+    const paymentProviderName = this.paymentService.providerName
 
     const result = await db.transaction(async (trx) => {
       const transaction = await Transaction.query({ client: trx })

--- a/app/services/payments/base_payment_service.ts
+++ b/app/services/payments/base_payment_service.ts
@@ -16,7 +16,7 @@ import app from '@adonisjs/core/services/app'
 import { DateTime } from 'luxon'
 
 export default abstract class BasePaymentService extends BaseService {
-  protected abstract providerName: PaymentProviderName
+  public abstract providerName: PaymentProviderName
   protected abstract getBanksEndpoint: string
   protected abstract resolveVerifyBankAccountEndpoint(
     bankCode: string,
@@ -257,7 +257,7 @@ export default abstract class BasePaymentService extends BaseService {
       `[PaymentService.initializeWalletTopup -> ${this.providerName}] Wallet Topup initialization successful.`
     )
 
-    return { data: data.data, paymentProviderName: this.providerName }
+    return { data: data.data }
   }
 
   public async verifyWalletTopup({ reference }: { reference: string }) {
@@ -306,7 +306,7 @@ export default abstract class BasePaymentService extends BaseService {
       `[PaymentService.verifyWalletTopup -> ${this.providerName}] Wallet Topup verification successful.`
     )
 
-    return { response: data, paymentProviderName: this.providerName }
+    return { response: data }
   }
 
   public verifyWebhookSignature(request: HttpContext['request']): boolean {

--- a/app/services/payments/paystack_provider.ts
+++ b/app/services/payments/paystack_provider.ts
@@ -3,7 +3,7 @@ import env from '#start/env'
 import BasePaymentService from './base_payment_service.js'
 
 export default class PaystackProvider extends BasePaymentService {
-  protected providerName: PaymentProviderName = 'paystack'
+  public providerName: PaymentProviderName = 'paystack'
 
   #baseUrl: string = paystackBaseUrl
 


### PR DESCRIPTION
Related to this issue: https://github.com/FarmXnap/FarmXnap-Backend/issues/4, this PR fixes an issue from this PR's implementation: https://github.com/FarmXnap/FarmXnap-Backend/pull/26.

It stores the payment provider name as soon as the transaction is created, preventing null provider name field on error in the payment service.